### PR TITLE
changind op_type to index

### DIFF
--- a/src/Connection/ElasticConnection.php
+++ b/src/Connection/ElasticConnection.php
@@ -150,7 +150,7 @@ class ElasticConnection implements ElasticConnectionInterface {
         $defaultParams = array(
             'index' => $index,
             'type' => $type,
-            'op_type' => 'create',
+            'op_type' => 'index',
             'timestamp' => time(),
             'refresh' => "true",
             'body' => $body


### PR DESCRIPTION
Changing the op_type value for the operation insert to "index" for compabilities issues with newers versions  of elasticsearch client.